### PR TITLE
Incorrect evaluation example

### DIFF
--- a/tests/baselines/reference/unknownType1.js
+++ b/tests/baselines/reference/unknownType1.js
@@ -17,7 +17,7 @@ type T12 = unknown | null | undefined;  // unknown
 type T13 = unknown | string;  // unknown
 type T14 = unknown | string[];  // unknown
 type T15 = unknown | unknown;  // unknown
-type T16 = unknown | any;  // any
+type T16 = unknown | any;  // unknown
 
 // Type variable and unknown in union and intersection
 


### PR DESCRIPTION
The documentation says that in a union an `unknown` absorbs everything, but that is *not* what was reflected in the documentation.

This updates the documentation to fix the evaluation example.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
